### PR TITLE
fix segmented browse

### DIFF
--- a/src/lib/routes/browse/get-domains.ts
+++ b/src/lib/routes/browse/get-domains.ts
@@ -19,6 +19,10 @@ const BROWSE_FILTER_MAP: Record<
   u_z: { start: 'u', end: 'z' },
 } as const;
 
+function getBoundedEndCharacter(text: string): string {
+  return String.fromCharCode(text.charCodeAt(0) + 1);
+}
+
 export async function getDomains(
   db: Database,
   {
@@ -53,7 +57,7 @@ export async function getDomains(
       $offset: page * size,
       $limit: size,
       $start: start || undefined,
-      $end: end || undefined,
+      $end: end.length > 0 ? getBoundedEndCharacter(end) : undefined,
     },
   );
   const domainRows = rows.map((row) => domain.parse(row));

--- a/src/lib/utils/pagination.ts
+++ b/src/lib/utils/pagination.ts
@@ -5,5 +5,5 @@ function isCountInteger(value: unknown): value is number {
 export function normalizePageCount(maybeCount: unknown, size: number): number {
   const count = isCountInteger(maybeCount) ? maybeCount : 0;
 
-  return Math.round(count / size);
+  return Math.ceil(count / size) - 1;
 }


### PR DESCRIPTION
Two issues - one, the function `normalizePageCount` did not subtract 1. Second when using `BETWEEN` in SQL statement, _for some reason_ (according to docs it should be possible) the "high" value is not inclusive. So I rely on ASCII to shift the high value by one position.